### PR TITLE
Initialize PRNG only once, since it's expensive (at least on Mac OS X)

### DIFF
--- a/bench/src/cpp/README.md
+++ b/bench/src/cpp/README.md
@@ -1,0 +1,14 @@
+# Building and testing slow events
+
+Slow event tool shows channel behaviour in extreme cases, with a
+lot of channels and listening threads.
+
+Compile ```event``` binary
+
+    g++ -std=c++11 -I./include bench/src/cpp/event.cpp -o event
+
+Run it using either with ```wait``` or ```try_once``` options
+
+   ./event wait
+   ./event try_once
+

--- a/bench/src/cpp/event.cpp
+++ b/bench/src/cpp/event.cpp
@@ -1,0 +1,110 @@
+#include <channel>
+#include <vector>
+#include <iostream>
+
+static bool g_exit = false;
+static std::mutex g_cout_mutex;
+
+// Listen using wait()
+void listen_wait(cpp::channel<char> c)
+{
+  {
+    std::lock_guard<std::mutex> lock(g_cout_mutex);
+    std::cout << "Starting listen_wait() listener" << std::endl;
+  }
+  bool exit = false;
+  while (!exit) {
+    cpp::select().recv(c, [&exit](char c) {
+      if (c == '!')
+        exit = true;
+      std::lock_guard<std::mutex> lock(g_cout_mutex);
+      std::cout << c << std::endl;
+    }).wait();
+  }
+  {
+    std::lock_guard<std::mutex> lock(g_cout_mutex);
+    std::cout << "Exiting listen_wait() listener" << std::endl;
+  }
+}
+
+// Listen using try_once()
+void listen_try_once(cpp::channel<char> c)
+{
+  {
+    std::lock_guard<std::mutex> lock(g_cout_mutex);
+    std::cout << "Starting try_once() listener" << std::endl;
+  }
+  bool exit = false;
+  while (!exit) {
+    cpp::select().recv(c, [&exit](char c) {
+      if (c == '!')
+        exit = true;
+      std::lock_guard<std::mutex> lock(g_cout_mutex);
+      std::cout << c << std::endl;
+    }).try_once();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  {
+    std::lock_guard<std::mutex> lock(g_cout_mutex);
+    std::cout << "Exiting try_once() listener" << std::endl;
+  }
+}
+
+// Simulation case for slow event waiting
+int main(int argc, char * argv[])
+{
+  constexpr unsigned int thread_count = 10;
+  constexpr unsigned int channel_count = 100;
+
+  if (argc != 2)
+  {
+    std::cout << "Specify either 'wait' or 'try_once'" << std::endl;
+    return 1;
+  }
+  std::string mode(argv[1]);
+  if (mode != "wait" && mode != "try_once")
+  {
+    std::cout << "Specify either 'wait' or 'try_once'" << std::endl;
+    return 1;
+  }
+
+  std::vector<std::thread> listeners;
+  std::vector<cpp::channel<char>> channels;
+
+  for (auto c = 0; c < channel_count; c++)
+  {
+    cpp::channel<char> events;
+    channels.push_back(events);
+    for (auto i = 0; i < thread_count; i++)
+    {
+      if (mode == "wait")
+        listeners.push_back(std::thread(listen_wait, events));
+      else
+        listeners.push_back(std::thread(listen_try_once, events));
+    }
+  }
+
+  std::string message("Hello World");
+  for (auto& c : message)
+  {
+    for (auto& channel : channels)
+    {
+      channel.send(c);
+    }
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+  }
+  for (auto c = 0; c < channel_count; c++)
+  {
+    for (auto i = 0; i < thread_count; i++)
+    {
+      channels.at(c).send('!');
+    }
+  }
+  for (auto& t : listeners)
+  {
+    if (t.joinable())
+      t.join();
+  }
+  return EXIT_SUCCESS;
+}
+

--- a/include/channel.h
+++ b/include/channel.h
@@ -519,14 +519,12 @@ private:
   typedef std::vector<try_function> try_functions;
   try_functions m_try_functions;
 
-  std::random_device random_device;
   std::mt19937 random_gen;
 
 public:
   select()
   : m_try_functions(),
-    random_device(),
-    random_gen(random_device()) {}
+    random_gen(std::time(nullptr)) {}
 
   /* send cases */
 


### PR DESCRIPTION
New PRNG instances are created for each select call. When using select()
function with try_once() with slow-moving and numerous channels (update
loop in interactive graphics application), it causes a lot of PRNG
initializations just to check if there's a value in the channel.

Example:

   cpp::select().recv_only(c, i).try_once()

This fix moves the random_gen to static member of internal namespace,
so it's initialized once and reused whenever new select() is done.

Based on measurements, this drops the try_once() in profiler list
from taking 30% of the execution time to something like 3%.