### PR TITLE
Introduce optional sleep=... option to wait() to reduce CPU usage

### DIFF
--- a/include/channel.h
+++ b/include/channel.h
@@ -625,6 +625,22 @@ public:
         break;
     }
   }
+
+  // Propagates any exception thrown by std::this_thread::sleep_for
+  template<class Rep, class Period>
+  void wait(const std::chrono::duration<Rep, Period>& sleep)
+  {
+    const try_functions::size_type n = m_try_functions.size();
+    try_functions::size_type i = random_gen();
+    for(;;)
+    {
+      i = (i + 1) % n;
+      if (m_try_functions.at(i)())
+        break;
+
+      std::this_thread::sleep_for(sleep);
+    }
+  }
 };
 
 template<class T, std::size_t N>


### PR DESCRIPTION
This is one change that has been useful for us so I decided to offer it as a pull request.

It allows us to specify optional sleep (in nanoseconds) and if given, it calls ```std::this_thread::sleep_for(...)``` with the given delay. This dramatically reduces the CPU load if there's no channel activity.